### PR TITLE
Development

### DIFF
--- a/demo/frosting/Program.cs
+++ b/demo/frosting/Program.cs
@@ -1,6 +1,8 @@
 ﻿using Cake.Frosting;
 using Cake.VulnerabilityScanner;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -29,7 +31,11 @@ namespace Build
                 OssIndexBaseUrl="https://ossindex.sonatype.org/",
                 OssIndexToken=ossIndexToken,
                 SolutionFile="../../../../../Cake.VulnerabilityScanner.sln",
-                Verbosity= Microsoft.Extensions.Logging.LogLevel.Debug
+                Verbosity= Microsoft.Extensions.Logging.LogLevel.Debug,
+                postScanCallback= (pacakgesInfo, scanResult) =>
+                {
+                    new PostScanHandler().Handle(pacakgesInfo, scanResult?.ToList());
+                } 
             }, CancellationToken.None);
         }
     }
@@ -40,4 +46,13 @@ namespace Build
     {
     }
 
+    public class PostScanHandler
+    {
+        public void Handle(List<PackageInfo> packageInfos, List<ComponentReport> componentReports)
+        {
+            // the passed data could be processed here, for instance saved to a data store.
+            Console.WriteLine("{0} pacakges have been found",packageInfos?.Count);
+            Console.WriteLine("{0} pacakges with Vulnerabilities have been  found ", componentReports?.Count(x=> x.Vulnerabilities.Any()));
+        }
+    }
 }

--- a/src/Cake.VulnerabilityScanner/CakeAlias/ScannerCakeAlias.cs
+++ b/src/Cake.VulnerabilityScanner/CakeAlias/ScannerCakeAlias.cs
@@ -1,6 +1,5 @@
 ﻿using Cake.Core;
 using Cake.Core.Annotations;
-using DependencyBot.Infrastructure.WebClient;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Cake.VulnerabilityScanner/Exceptions/VulnerabilityException.cs
+++ b/src/Cake.VulnerabilityScanner/Exceptions/VulnerabilityException.cs
@@ -1,7 +1,5 @@
-﻿using DependencyBot.Infrastructure.WebClient;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Runtime.Serialization;
 
 namespace Cake.VulnerabilityScanner
 {

--- a/src/Cake.VulnerabilityScanner/IVulnerabilityScanner.cs
+++ b/src/Cake.VulnerabilityScanner/IVulnerabilityScanner.cs
@@ -1,5 +1,4 @@
-﻿using DependencyBot.Infrastructure.WebClient;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Cake.VulnerabilityScanner

--- a/src/Cake.VulnerabilityScanner/OpenAPIs/OssIndexClient.cs
+++ b/src/Cake.VulnerabilityScanner/OpenAPIs/OssIndexClient.cs
@@ -12,7 +12,7 @@
 #pragma warning disable 8073 // Disable "CS8073 The result of the expression is always 'false' since a value of type 'T' is never equal to 'null' of type 'T?'"
 #pragma warning disable 3016 // Disable "CS3016 Arrays as attribute arguments is not CLS-compliant"
 
-namespace DependencyBot.Infrastructure.WebClient
+namespace Cake.VulnerabilityScanner
 {
     using System = global::System;
 

--- a/src/Cake.VulnerabilityScanner/PostScanCallback.cs
+++ b/src/Cake.VulnerabilityScanner/PostScanCallback.cs
@@ -1,0 +1,8 @@
+﻿using System.Collections.Generic;
+
+namespace Cake.VulnerabilityScanner
+{
+
+
+    public delegate void PostScanCallback(List<PackageInfo> packageInfos, ICollection<ComponentReport> componentReports);
+}

--- a/src/Cake.VulnerabilityScanner/Settings/ScanPackageSettings.cs
+++ b/src/Cake.VulnerabilityScanner/Settings/ScanPackageSettings.cs
@@ -7,11 +7,47 @@ namespace Cake.VulnerabilityScanner
     /// </summary>
     public class ScanPackagesSettings
     {
+        /// <summary>
+        /// OssIndex base url 
+        /// </summary>
         public string OssIndexBaseUrl { get; set; }
+
+        /// <summary>
+        /// OssIndex API token
+        /// If not provided OssIndex will be called without authentication
+        /// Calls with authentication has higher rate limit
+        /// <href>https://ossindex.sonatype.org/doc/rest</href>
+        /// </summary>
         public string OssIndexToken { get; set; }
+
+        /// <summary>
+        /// .sln file , or .csproj
+        /// </summary>
         public string SolutionFile { get; set; }
+
+        /// <summary>
+        /// If true, the scan throws an exception when a Vulnerability is found
+        /// </summary>
         public bool FailOnVulnerability { get; set; }
+
+        /// <summary>
+        /// example, nuget, npm, and so on 
+        /// <href>https://ossindex.sonatype.org/ecosystems</href>
+        /// </summary>
         public string Ecosystem { get; set; }
+
+        /// <summary>
+        /// Log level
+        /// </summary>
         public LogLevel Verbosity { get; set; }
+
+
+        /// <summary>
+        /// If set, it will be called with pacakges info and scan result passed to it
+        ///  this could be used a custom logic that will be called after the scan, 
+        /// for instnace sending pacakges info and scan results to a certain data store
+        /// </summary>
+        public PostScanCallback postScanCallback { get; set; }
+
     }
 }

--- a/src/Cake.VulnerabilityScanner/VulnerabilityScanner.cs
+++ b/src/Cake.VulnerabilityScanner/VulnerabilityScanner.cs
@@ -1,5 +1,4 @@
-﻿using DependencyBot.Infrastructure.WebClient;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -25,12 +24,13 @@ namespace Cake.VulnerabilityScanner
         {
             var scanner = new DependenciesAnalyzer();
             var packages = scanner.GetDependencies(settings.SolutionFile);
-           
+
             _logger.LogInformation("{0} Packages found in the solution {1}", packages.Count, settings.SolutionFile);
             packages.ForEach(p => _logger.LogDebug("{0}:{1}", p.PackageId, p.Version));
 
-            _httpClient.BaseAddress = new Uri(settings.OssIndexBaseUrl); 
-            _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("basic", settings.OssIndexToken);
+            _httpClient.BaseAddress = new Uri(settings.OssIndexBaseUrl);
+            if (!string.IsNullOrWhiteSpace(settings.OssIndexToken))
+                _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("basic", settings.OssIndexToken);
             var vulnerabilityClient = new OssIndexWebClient(_httpClient);
 
             List<string> ossIndexCoordinates = BuildOssIndexCoordinates(settings, packages);
@@ -45,12 +45,16 @@ namespace Cake.VulnerabilityScanner
                 if (settings.FailOnVulnerability && reports.Any(r => r.Vulnerabilities.Any()))
                     throw new VulnerabilityException(message: "Vulnerability detected", reports.ToList());
 
-                else return reports.ToList();
+
+                if (settings.postScanCallback != null)
+                    settings.postScanCallback(packages, reports);
+
+                return reports.ToList(); 
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error calling ossIndex");
-                throw ;
+                throw;
             }
 
         }


### PR DESCRIPTION
Added PostScanCallback Delegate, which could be used for any after scan processing, for instance storing dependencies in a datastore 